### PR TITLE
Add vulnerability location field when persisting a vulnerability.

### DIFF
--- a/agent/local_persist_vulnz_agent.py
+++ b/agent/local_persist_vulnz_agent.py
@@ -35,6 +35,7 @@ class LocalPersistVulnzAgent(agent.Agent):
                                     short_description=message.data['short_description'],
                                     description=message.data['description'],
                                     recommendation=message.data['recommendation'],
+                                    references=message.data.get('references', []),
                                     technical_detail=message.data['technical_detail'],
                                     risk_rating=message.data['risk_rating'],
                                     cvss_v3_vector=message.data['cvss_v3_vector'],

--- a/agent/local_persist_vulnz_agent.py
+++ b/agent/local_persist_vulnz_agent.py
@@ -38,7 +38,8 @@ class LocalPersistVulnzAgent(agent.Agent):
                                     technical_detail=message.data['technical_detail'],
                                     risk_rating=message.data['risk_rating'],
                                     cvss_v3_vector=message.data['cvss_v3_vector'],
-                                    dna=message.data.get('dna'))
+                                    dna=message.data.get('dna'),
+                                    location=message.data.get('vulnerability_location', {}))
         logger.info('vulnerability persisted')
 
 

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1,14 +1,14 @@
 """Unittests for local_persist_vulnz agent."""
-from unittest import mock
-
 from ostorlab.runtimes.local.models import models
 
 
-@mock.patch('ostorlab.runtimes.local.models.models.ENGINE_URL', 'sqlite:////tmp/ostorlab_db1.sqlite')
 def testLocalPersistVulnzAgent_always_VulnPersistedToLocalDB(
+        mocker,
+        db_engine_path,
         agent_mock,
         persist_vulnz_agent,
         scan_message):
+    mocker.patch.object(models, 'ENGINE_URL', db_engine_path)
 
     with models.Database() as session:
         init_count = session.query(models.Vulnerability).count()

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -9,6 +9,13 @@ def testLocalPersistVulnzAgent_always_VulnPersistedToLocalDB(
         agent_mock,
         persist_vulnz_agent,
         scan_message):
-    init_count = models.Database().session.query(models.Vulnerability).count()
-    persist_vulnz_agent.process(scan_message)
-    assert models.Database().session.query(models.Vulnerability).count() == init_count + 1
+
+    with models.Database() as session:
+        init_count = session.query(models.Vulnerability).count()
+        persist_vulnz_agent.process(scan_message)
+        vuln = session.query(models.Vulnerability).first()
+
+        assert session.query(models.Vulnerability).count() == init_count + 1
+        assert 'My reference: https://ostorlab.co' in vuln.references
+        assert 'Domain: dummy.co' in vuln.location
+        assert 'URL: https://dummy.co/path1' in vuln.location

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,8 +56,6 @@ def persist_vulnz_agent():
         bus_management_url='http://guest:guest@localhost:15672/',
         bus_vhost='/',
     )
-    database = models.Database()
-    database.create_db_tables()
     scan = models.Scan.create('test')
     os.environ['UNIVERSE'] = str(scan.id)
     agent = agent_local_persist_vulnz.LocalPersistVulnzAgent(definition, settings)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from agent import local_persist_vulnz_agent as agent_local_persist_vulnz
 
 @pytest.fixture
 def scan_message():
-    """Creates a dummy message of type v3.asset.file to be used by the agent for testing purposes.
+    """Creates a dummy message of type v3.report.vulnerability to be used by the agent for testing purposes.
     The files used is the EICAR Anti-Virus Test File.
     """
     selector = 'v3.report.vulnerability'
@@ -32,7 +32,11 @@ def scan_message():
             'targeted_by_malware': False,
             'targeted_by_ransomware': False,
             'targeted_by_nation_state': False,
-            'dna': 'dna'
+            'dna': 'dna',
+            'vulnerability_location': {
+                'domain_name': {'name': 'dummy.co'},
+                'metadata': [{'type': 'URL', 'value': 'https://dummy.co/path1'}]
+            }
         }
     return message.Message.from_data(selector, data=msg_data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,23 @@
 """Pytest fixture for the local_persist_vulnz agent."""
 import os
-import pytest
+import sys
 
-from unittest import mock
+import pytest
 
 from ostorlab.agent import definitions as agent_definitions
 from ostorlab.runtimes import definitions as runtime_definitions
 from ostorlab.runtimes.local.models import models
 from ostorlab.agent.message import message
 from agent import local_persist_vulnz_agent as agent_local_persist_vulnz
+
+
+@pytest.fixture()
+def db_engine_path(tmpdir):
+    if sys.platform == 'win32':
+        path = f'sqlite:///{tmpdir}\\ostorlab_db1.sqlite'.replace('\\', '\\\\')
+    else:
+        path = f'sqlite:////{tmpdir}/ostorlab_db1.sqlite'
+    return path
 
 
 @pytest.fixture
@@ -42,9 +51,9 @@ def scan_message():
 
 
 @pytest.fixture
-@mock.patch('ostorlab.runtimes.local.models.models.ENGINE_URL', 'sqlite:////tmp/ostorlab_db1.sqlite')
-def persist_vulnz_agent():
+def persist_vulnz_agent(mocker, db_engine_path):
     """Instantiate local_persist_vulnz agent."""
+    mocker.patch.object(models, 'ENGINE_URL', db_engine_path)
     definition = agent_definitions.AgentDefinition(
         name='agent_local_persist_vulnz',
         out_selectors=[],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,8 @@ from ostorlab.agent.message import message
 from agent import local_persist_vulnz_agent as agent_local_persist_vulnz
 
 
-@pytest.fixture()
-def db_engine_path(tmpdir):
+@pytest.fixture(name='db_engine_path')
+def db_engine_tmp_path(tmpdir):
     if sys.platform == 'win32':
         path = f'sqlite:///{tmpdir}\\ostorlab_db1.sqlite'.replace('\\', '\\\\')
     else:


### PR DESCRIPTION
This PR adds the vulnerability location field when persisting a vulnerability locally. This a follow up to the current work on the ostorlab scan engine to add which exact target where the vulnerability was found.