### PR TITLE
feature: add exploitation and post exploitation to local persist vulnz

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ _PersistVulnz locally persists vulnerabilities discovered after a scan is run._
 
 ---
 
-<p align="center">
-<img src="" alt="agent_persist_vulnz" />
-</p>
-
 This repository is an implementation of the default persist vulnz agent. Persist Vulnz is a default agent needed to run a scan using the local runtime.
 
 ## Usage
@@ -25,7 +21,7 @@ Agent Persist Vulnz can be installed directly from the oxo agent store or built 
  ### Install directly from oxo agent store
 
  ```shell
- oxooxo agent install agent/ostorlab/local_persist_vulnz
+ oxo agent install agent/ostorlab/local_persist_vulnz
  ```
 The agent will be automatically installed and updated by simply passing `--install` flag:
 

--- a/agent/local_persist_vulnz_agent.py
+++ b/agent/local_persist_vulnz_agent.py
@@ -39,6 +39,8 @@ class LocalPersistVulnzAgent(agent.Agent):
             recommendation=message.data["recommendation"],
             references=message.data.get("references", []),
             technical_detail=message.data["technical_detail"],
+            exploitation_detail=message.data.get("exploitation_detail"),
+            post_exploitation_detail=message.data.get("post_exploitation_detail"),
             risk_rating=message.data["risk_rating"],
             cvss_v3_vector=message.data["cvss_v3_vector"],
             dna=message.data.get("dna"),

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -17,3 +17,5 @@ def testLocalPersistVulnzAgent_always_VulnPersistedToLocalDB(
         assert "My reference: https://ostorlab.co" in vuln.references
         assert "Domain: `dummy.co`" in vuln.location
         assert "URL: https://dummy.co/path1" in vuln.location
+        assert "exploitation steps" in vuln.exploitation_detail
+        assert "post exploitation steps" in vuln.post_exploitation_detail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,8 @@ def scan_message():
     msg_data = {
         "title": "my vuln",
         "technical_detail": "print $1",
+        "exploitation_detail": "exploitation steps",
+        "post_exploitation_detail": "post exploitation steps",
         "risk_rating": "HIGH",
         "cvss_v3_vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
         "short_description": "Control user input",


### PR DESCRIPTION
This PR do:
- add exploitation and post exploitation to local persist vulnz to persist the fields in local scans
- fix readme file errors